### PR TITLE
Remove excluded archs from podspec

### DIFF
--- a/PrimerIPay88MYSDK.podspec
+++ b/PrimerIPay88MYSDK.podspec
@@ -28,10 +28,6 @@ Pod::Spec.new do |s|
     
     s.ios.deployment_target = '10.0'
     
-    s.xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-    
     s.source_files = 'PrimerIPay88SDK/Classes/**/*', 'PrimerIPay88SDK/Frameworks/Ipay.h', 'PrimerIPay88SDK/Frameworks/IpayPayment.h', 'PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework'
     s.vendored_frameworks = 'PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework'
 end


### PR DESCRIPTION
The latest xcframework includes M1 simulator arch so we no longer needed to exclude it.

Note this repo no longer has a sample app, so it can only be tested via the Debug app. Ticket [here](https://primerapi.atlassian.net/browse/CHKT-1653).

To test:
- Point your Debug apps podfile to this branch.
- `pod deintegrate`, `pod install`, `clean build` to be safe
- Build Debug App without Rosetta (Xcode `Product>Destinations>Destination Architectures` will allow you to choose)
- Profit

<img width="945" alt="Screenshot 2023-09-06 at 16 50 03" src="https://github.com/primer-io/primer-ipay88-sdk-ios/assets/3179752/3798d6fb-3cd7-4dd0-8539-c86619951a43">

